### PR TITLE
Workaround `bundler` moduleResolution with node specific import

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,19 @@
+name: Build
+on:
+  pull_request:
+    branches: [ "main" ]
+  push:
+  workflow_dispatch:  # Allows manual triggering
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20.x
+      - name: Install dependencies
+        run: npm install
+      - name: Compile and build
+        run: npm run build

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ TypeScript throw an error when doing the following:
 import { parseFile } from "music-metadata";
 ```
 
-Because `node_modules/music-metadata/lib/core.d.ts` does not include a type for `parseFile`.
+Because `node_modules/music-metadata/lib/index.d.ts` does not include a type for `parseFile`.
 
 Adding `// @ts-expect-error` allows the application to build successfully, so it seems to just a types issue.
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,6 +9,7 @@
     "esModuleInterop": true,
     "module": "esnext",
     "moduleResolution": "bundler",
+    "customConditions": ["node"],
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "preserve",


### PR DESCRIPTION
Adds static  `"node"` as a static `customConditions`, as with `bundler` as the `moduleResolution` this condition is not automatically set, by the TypeScript compiler.

I have also added workflow, building the project, proving this solves the issue.

Resolves https://github.com/Borewit/music-metadata/issues/2370